### PR TITLE
Attach toString to make Radium filter out nested style definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf lib",
     "build": "babel src --out-dir lib",
     "test": "NODE_ENV=test mocha",
-    "prepublish": "npm run test && npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/jfschwarz/substyle#readme",
   "dependencies": {
     "invariant": "^2.2.0",
-    "lodash": "^4.3.0",
+    "lodash": "^4.5.0",
     "warning": "^2.1.0"
   },
   "devDependencies": {

--- a/src/substyle.js
+++ b/src/substyle.js
@@ -7,7 +7,9 @@ import flatten from 'lodash/flatten'
 import merge from 'lodash/merge'
 import filter from 'lodash/fp/filter'
 import map from 'lodash/fp/map'
+import mapValues from 'lodash/mapValues'
 import compose from 'lodash/fp/compose'
+import isPlainObject from 'lodash/isPlainObject'
 
 
 export default function substyle({ style, className }, selectedKeys) {
@@ -42,9 +44,9 @@ export default function substyle({ style, className }, selectedKeys) {
   return {
 
     ...( style && { 
-      style : merge({},
+      style : attachToStringToObjects(merge({},
         ...hoistElementStylesFromEach([ style, ...hoistModifierStyles(style) ])
-      )
+      ))
     }),
 
     ...( className && { 
@@ -59,6 +61,7 @@ export default function substyle({ style, className }, selectedKeys) {
 }
 
 const isModifier = key => key[0] === '&'
+const isPseudoOrMedia = key => key[0] === ':' || key[0] === '@'
 const isElement = negate(isModifier)
 
 const pickNestedStyles = (style, keysToPick) => {
@@ -75,3 +78,11 @@ const pickNestedStyles = (style, keysToPick) => {
 }
 
 const camelize = key => key.replace(/-(\w)/g, (m, c) => c.toUpperCase())
+
+const attachToStringToObjects = ({ toString, ...styles }) => mapValues(styles, (value, key, ...args) => {
+  if(!isPseudoOrMedia(key) && Object.prototype.toString.call(value) === '[object Object]') {
+    value = {...value}
+    value.toString = () => undefined
+  }
+  return value
+})

--- a/test/defaultStyle.specs.js
+++ b/test/defaultStyle.specs.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { stripToStrings } from './utils'
 import { defaultStyle } from '../src'
 
 describe('defaultStyle', function () {
@@ -9,8 +10,8 @@ describe('defaultStyle', function () {
        { nested: { height: 10, width: 10 }}
      ) 
      const props = { style: { height: 50, nested: { width: 20 } } }
-     expect(substyleWithDefaultStyles(props)).to.deep.equal({ style: { height: 50, width: 50, nested: { height: 10, width: 20 } } })
-     expect(substyleWithDefaultStyles(props, 'nested')).to.deep.equal({ style: { height: 10, width: 20 } })
+     expect(stripToStrings(substyleWithDefaultStyles(props).style)).to.deep.equal({ height: 50, width: 50, nested: { height: 10, width: 20 } })
+     expect(stripToStrings(substyleWithDefaultStyles(props, 'nested').style)).to.deep.equal({ height: 10, width: 20 })
   })
 
 })

--- a/test/substyle.specs.js
+++ b/test/substyle.specs.js
@@ -286,6 +286,16 @@ describe('substyle', function () {
     const { style } = substyle({ style: myStyle })
     expect(style.toggle.toString()).to.equal(undefined)
     expect(style['&active'].toString()).to.equal(undefined)
-  });
+  })
+
+  it('should not attach toString to nested pseudo class or media query objects', function () {
+    // this will cause the styles to be filtered out by Radium and prevents IE choking up
+    const { style } = substyle({ style: { 
+      ':hover': { color: 'red' },
+      '@media only screen and (min-width: 600px)': { color: 'red' } 
+    } })
+    expect(style[':hover'].toString).to.equal(Object.prototype.toString)
+    expect(style['@media only screen and (min-width: 600px)'].toString).to.equal(Object.prototype.toString)
+  })
 
 })

--- a/test/substyle.specs.js
+++ b/test/substyle.specs.js
@@ -281,4 +281,11 @@ describe('substyle', function () {
     })
   })
 
+  it('should attach toString functions to all nested element/modifier styles', function () {
+    // this will cause the styles to be filtered out by Radium and prevents IE choking up
+    const { style } = substyle({ style: myStyle })
+    expect(style.toggle.toString()).to.equal(undefined)
+    expect(style['&active'].toString()).to.equal(undefined)
+  });
+
 })

--- a/test/substyle.specs.js
+++ b/test/substyle.specs.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-
+import { stripToStrings } from './utils'
 import substyle, { defaultStyle } from '../src'
 
 const myStyle = {
@@ -37,6 +37,8 @@ const myStyle = {
 
 }
 
+
+
 describe('substyle', function () {
 
   it('should derive a BEM compliant className for a passed nested element key', function () {
@@ -51,7 +53,7 @@ describe('substyle', function () {
 
   it('should should select the nested inline styles for the given key', function () {
     const { style } = substyle({ style: myStyle }, 'toggle')
-    expect(style).to.deep.equal({
+    expect(stripToStrings(style)).to.deep.equal({
       display: 'block',
       width: 50
     })
@@ -70,7 +72,7 @@ describe('substyle', function () {
 
   it('should include all direct style definitions if only modifier keys are used, hoisting those for the active modifiers', function () {
     const { style } = substyle({ style: myStyle }, '&active')
-    expect(style).to.deep.equal({ 
+    expect(stripToStrings(style)).to.deep.equal({ 
       ...myStyle,
       background: 'blue' // hoisted from &active
     })
@@ -78,7 +80,7 @@ describe('substyle', function () {
 
   it('should merge element styles nested under modifiers if selectedKeys contain both, element keys and modifier keys', function () {
     const { style } = substyle({ style: myStyle }, ['btn', '&disabled'])
-    expect(style).to.deep.equal({ 
+    expect(stripToStrings(style)).to.deep.equal({ 
       cursor: 'default',
     })
   })
@@ -95,7 +97,7 @@ describe('substyle', function () {
     )
 
     expect(className).to.equal('my-class__toggle my-class__btn')
-    expect(style).to.deep.equal({ 
+    expect(stripToStrings(style)).to.deep.equal({ 
       display: 'block',
       width: 50,
       cursor: 'pointer'
@@ -109,7 +111,7 @@ describe('substyle', function () {
     )
 
     expect(className).to.equal('my-class my-class--active my-class--disabled')
-    expect(style).to.deep.equal({ 
+    expect(stripToStrings(style)).to.deep.equal({ 
       ...myStyle,
 
       background: 'blue',    // hoisted from &active
@@ -177,7 +179,7 @@ describe('substyle', function () {
     }
 
     const { style } = substyle({ style: styleWithDeepNesting }, ['toggle', 'specialToggle'])
-    expect(style).to.deep.equal({
+    expect(stripToStrings(style)).to.deep.equal({
       width: 50,
 
       label: {
@@ -186,7 +188,7 @@ describe('substyle', function () {
       }
     })
     const { style: sameStyle } = substyle({ style: styleWithDeepNesting }, ['specialToggle', 'toggle'])
-    expect(sameStyle).to.deep.equal(style)
+    expect(stripToStrings(sameStyle)).to.deep.equal(stripToStrings(style))
 
     const styleWithOtherOrder = {
       specialToggle: {
@@ -207,7 +209,7 @@ describe('substyle', function () {
       }
     }
     const { style: otherStyle } = substyle({ style: styleWithOtherOrder }, ['toggle', 'specialToggle'])
-    expect(otherStyle).to.deep.equal({
+    expect(stripToStrings(otherStyle)).to.deep.equal({
       width: 100,
 
       label: {
@@ -231,7 +233,7 @@ describe('substyle', function () {
       }
     }
     const { style } = substyle({ style: myStyle }, ['toggle', '&narrow'])
-    expect(style).to.deep.equal({
+    expect(stripToStrings(style)).to.deep.equal({
       width: 50,
       color: 'red'
     })
@@ -245,7 +247,7 @@ describe('substyle', function () {
     }
 
     const { style } = substyle({ style: styleWithCamelCaseKey }, 'special-toggle')
-    expect(style).to.deep.equal({
+    expect(stripToStrings(style)).to.deep.equal({
       width: 50
     })
   })
@@ -266,7 +268,7 @@ describe('substyle', function () {
       }
     }
     const { style } = substyle(substyle({ style: myStyle }, '&outer'), '&inner')
-    expect(style).to.deep.equal({
+    expect(stripToStrings(style)).to.deep.equal({
       position: 'absolute',
       cursor: 'pointer',
       color: 'red',

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,10 @@
+import mapValues from 'lodash/mapValues'
+import isPlainObject from 'lodash/isPlainObject'
+
+export const stripToStrings = (obj) => mapValues(obj, val => {
+  if(isPlainObject(val)) {
+    const { toString, ...rest } = val
+    return rest;
+  }
+  return val;
+})


### PR DESCRIPTION
This fixes a problem when using substyle in IE. IE chokes when nested element styles end up in the style attribute as `nested:[object Object];`. 

Therefore we have to clean the result style from such unused objects. However, as substyle does not know whether its result is passed on to a composite component or a leaf DOM nodes, we can only achieve this by using substyle in combination with Radium.

Radium does some filtering of style props. The changes in the PR will make sure that Radium filters out all nested object style properties. They can probably be reverted once the following Radium issue is closed: https://github.com/FormidableLabs/radium/issues/634