### PR TITLE
Add babel-plugin-lodash to lower bundle size by 75%

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["babel-plugin-add-module-exports", "transform-flow-strip-types"]
+  "plugins": ["babel-plugin-add-module-exports", "transform-flow-strip-types", "lodash"]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-lodash": "3.2.11",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",


### PR DESCRIPTION
I really like the library [react-mentions](https://github.com/effektif/react-mentions) and decided to use it on my project, but was disappointed to see my minified bundle size increase by ~180kb (60kb gzip) -- almost a third of my bundle devoted to just the react-mentions library. I dug in a little bit and realized the bulk of the size was the entirety of `lodash` imported by this library, which is imported by `react-mentions`. 

This uses the babel-plugin-lodash to automatically turn instances of 
`var _ = require('lodash'); _.identity()` into `var _identity2 = require('lodash/identity') itentity2()`; using babel, which you were already running to run your build. I could have manually changed everything, but I figured it might be easier for you to maintain this way as you can keep importing functions from lodash the way you have been. 

The savings are huge when this library (by way of react-mentions) is imported using webpack (I'm assuming similar savings with browserify as well): **~130kb (45kb gzip) reduction in minimized filesize**. 

This means react-mentions is still close to 50kb minified (15kb gzipped), which is no small potatoes, but it's a huge improvement on before, **almost a quarter the size as before**. 

The next step after this is merged is to look into the uses of lodash in this lib and react-mentions and seeing if certain functions can be removed and replaced with vanillaJS and whether what they add in readability justifies the pageweight increase. 