### PR TITLE
Replace whole lodash imports with individual imports

### DIFF
--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,5 +1,8 @@
 // @flow
-import { mergeWith, isString, compact, keys } from 'lodash'
+import mergeWith from 'lodash/mergeWith';
+import isString from 'lodash/isString';
+import compact from 'lodash/compact';
+import keys from 'lodash/keys';
 
 import type { ClassNamesT, CoercedClassNamesT } from './types'
 

--- a/src/createSubstyle.js
+++ b/src/createSubstyle.js
@@ -1,10 +1,18 @@
 // @flow
 import invariant from 'invariant'
-import {
-  keys, values, merge, assign, compact,
-  isFunction, isPlainObject, isString, isArray,
-} from 'lodash'
-import { filter, compose } from 'lodash/fp'
+
+import keys from 'lodash/keys'
+import values from 'lodash/values'
+import merge from 'lodash/merge'
+import assign from 'lodash/assign'
+import compact from 'lodash/compact'
+import isFunction from 'lodash/isFunction'
+import isPlainObject from 'lodash/isPlainObject'
+import isString from 'lodash/isString'
+import isArray from 'lodash/isArray'
+
+import filter from 'lodash/fp/filter'
+import compose from 'lodash/fp/compose'
 
 import defaultPropsDecorator from './defaultPropsDecorator'
 import { pickNestedStyles, hoistModifierStylesRecursive } from './pickStyles'

--- a/src/defaultStyle.js
+++ b/src/defaultStyle.js
@@ -1,7 +1,8 @@
 // @flow
 import { createElement, Component } from 'react'
 import hoistStatics from 'hoist-non-react-statics'
-import { identity, isFunction } from 'lodash'
+import identity from 'lodash/identity'
+import isFunction from 'lodash/isFunction'
 
 import createSubstyle from './createSubstyle'
 import { PropTypes, ContextTypes, ENHANCER_CONTEXT_NAME } from './types'

--- a/src/filterKeys.js
+++ b/src/filterKeys.js
@@ -1,5 +1,5 @@
 // @flow
-import { negate } from 'lodash'
+import negate from 'lodash/negate'
 
 export const isModifier = (key: string) => key[0] === '&'
 export const isElement = negate(isModifier)

--- a/src/pickStyles.js
+++ b/src/pickStyles.js
@@ -1,4 +1,8 @@
-import { keys, merge, omit, values, filter } from 'lodash'
+import keys from 'lodash/keys' 
+import merge from 'lodash/merge' 
+import omit from 'lodash/omit' 
+import values from 'lodash/values' 
+import filter from 'lodash/filter'
 
 import { isModifier } from './filterKeys'
 


### PR DESCRIPTION
This change improves the webpack bundle size for projects using this module.
This is a patch change since there is no change on the module API.

__Before__:

<img width="708" alt="screen shot 2017-05-21 at 12 45 09 pm" src="https://cloud.githubusercontent.com/assets/27819/26286864/a9e1c316-3e23-11e7-8515-f11824621be2.png">

__After__:

<img width="850" alt="screen shot 2017-05-21 at 12 45 59 pm" src="https://cloud.githubusercontent.com/assets/27819/26286867/b4b1174c-3e23-11e7-809b-17574d4c0b18.png">
