### PR TITLE
EnhancerProvider is not a PureComponent and doesn't block updates

### DIFF
--- a/packages/substyle-glamor/yarn.lock
+++ b/packages/substyle-glamor/yarn.lock
@@ -662,10 +662,6 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -711,7 +707,7 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.6.0"
     css-in-js-utils "^1.0.3"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -918,7 +914,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1126,7 +1122,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -1330,16 +1326,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-substyle@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/substyle/-/substyle-6.1.2.tgz#f64d912c8c0f0339d3c16eda19fcced68699a533"
-  dependencies:
-    hoist-non-react-statics "^1.2.0"
-    invariant "^2.2.0"
-    lodash "^4.3.0"
-    prop-types "^15.5.8"
-    warning "^2.1.0"
-
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -1440,12 +1426,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-warning@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"

--- a/packages/substyle/src/EnhancerProvider.js
+++ b/packages/substyle/src/EnhancerProvider.js
@@ -1,13 +1,21 @@
 // @flow
-import { PureComponent, Children } from 'react'
+import * as React from 'react'
 import PropTypes from 'prop-types'
 import {
   ENHANCER_CONTEXT_NAME,
   PROPS_DECORATOR_CONTEXT_NAME,
   ContextTypes,
 } from './types'
+import type { EnhancerFuncT, DecoratorFuncT } from './types'
 
-export default class EnhancerProvider extends PureComponent {
+type PropsT = {
+  enhancer?: EnhancerFuncT,
+  propsDecorator?: DecoratorFuncT,
+
+  children: React.Node,
+}
+
+export default class EnhancerProvider extends React.Component<PropsT, void> {
   getChildContext() {
     return {
       [ENHANCER_CONTEXT_NAME]: this.props.enhancer,
@@ -16,7 +24,7 @@ export default class EnhancerProvider extends PureComponent {
   }
 
   render() {
-    return Children.only(this.props.children)
+    return React.Children.only(this.props.children)
   }
 }
 

--- a/packages/substyle/src/types.js
+++ b/packages/substyle/src/types.js
@@ -1,5 +1,6 @@
 // @flow
 import PT from 'prop-types'
+import * as React from 'react'
 
 export const ENHANCER_CONTEXT_NAME = '__substyle__enhancer'
 export const PROPS_DECORATOR_CONTEXT_NAME = '__substyle__propsDecorator'
@@ -30,10 +31,16 @@ export const PropTypes = {
   classNames: ClassNamesPT,
 }
 
-export type ContextT = {
-  [ENHANCER_CONTEXT_NAME]: ?(WrappedComponent: ReactClass) => ReactClass,
-  [PROPS_DECORATOR_CONTEXT_NAME]: ?(props: PropsT) => Object,
-}
+export type EnhancerFuncT = (
+  WrappedComponent: React.ComponentType<*>
+) => React.ComponentType<*>
+
+export type DecoratorFuncT = (props: PropsT) => Object
+
+export type ContextT = {|
+  __substyle__enhancer?: EnhancerFuncT,
+  __substyle__propsDecorator?: DecoratorFuncT,
+|}
 
 export const ContextTypes = {
   [ENHANCER_CONTEXT_NAME]: PT.func,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,18 +2461,18 @@ ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
-react-dom@16:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+react-dom@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@16:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+react@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Since the `<EnhancerProvider />` is usually something you wrap around your application, it can be problematic if this component is a `PureComponent`. In our case, it prevented route updates.

**Does not work**
```es6
<Router>
  <EnhancerProvider>
    <Application />
  </EnhancerProvider>
</Router>
```

**Works**
```es6
<EnhancerProvider>
  <Router>
    <Application />
  </Router>
</EnhancerProvider>
```

You can imagine the fun I had, debugging this. 