### PR TITLE
Refactored omit util (for improved legacy browser support)

### DIFF
--- a/packages/substyle/src/utils.js
+++ b/packages/substyle/src/utils.js
@@ -36,10 +36,10 @@ export const identity = value => {
 }
 
 export const omit = (obj, keys: string[]) => {
-  const { ...other } = { ...obj }
+  const other = Object.assign({}, obj)
   if (keys) {
-    for (const key of keys) {
-      delete other[key]
+    for (let i = 0; i < keys.length; i++) {
+      delete other[keys[i]]
     }
   }
   return other


### PR DESCRIPTION
This fixes #36 by removing the usage of `Symbol.iterator` from the compiled library code.

Tests are passing on my machine:
```
yarn run v1.16.0
$ jest
 PASS  test/classNames.spec.js
 PASS  test/index.spec.js
 PASS  test/utils.spec.js
 PASS  test/EnhancerProvider.spec.js
 PASS  test/defaultStyle.spec.js

Test Suites: 5 passed, 5 total
Tests:       38 passed, 38 total
Snapshots:   0 total
Time:        5.784s
Ran all test suites.
Done in 6.93s.
```